### PR TITLE
fix: invert alert hint conditional

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -72,7 +72,7 @@
 	
 <div class="container mx-auto flex flex-col items-center justify-center pb-4 sm:w-2xl">
 	
-	{#if !showAutoLocationHint}
+	{#if showAutoLocationHint}
 		<div class="px-4 w-full mt-4">
 			<div class="alert bg-base-100 mb-2 relative">
 				<i class="icon-[ph--info] size-6 shrink-0"></i>


### PR DESCRIPTION
Fixed the auto-location hint alert conditional that was showing the hint when it should have been hidden.

The conditional  has been corrected to .