### PR TITLE
Fix kuschelraum, seijetzt, and ggbrandenburg scrapers

### DIFF
--- a/scripts/scrape-ggbrandenburg.ts
+++ b/scripts/scrape-ggbrandenburg.ts
@@ -90,6 +90,13 @@ export class WebsiteScraper implements WebsiteScraperInterface {
         let dateTimeElement = $('h5').first().text();
         // Clean up invisible characters like zero-width space
         dateTimeElement = dateTimeElement.replace(/[\u200B-\u200D\uFEFF]/g, '');
+        
+        // Skip if no date/time element found
+        if (!dateTimeElement || dateTimeElement.trim() === '') {
+            console.error('No date/time element found in h5');
+            return undefined;
+        }
+        
         // Parse multi-day patterns first: "05.09.2025 bis 07.09.2025 von 17:00 – 00:00 Uhr"
         const multiDayMatch = dateTimeElement.match(/(\d{2})\.(\d{2})\.(\d{4})\s+bis\s+\d{2}\.\d{2}\.\d{4}\s+von\s+(\d{1,2}):(\d{2})/);
         if (multiDayMatch) {

--- a/scripts/scrape-kuschelraum.ts
+++ b/scripts/scrape-kuschelraum.ts
@@ -331,8 +331,21 @@ export class WebsiteScraper implements WebsiteScraperInterface {
     extractStartAt(html: string) {
         const $ = cheerio.load(html);
         const timeText = $('.mec-single-event-time abbr').text(); // 16:00 - 18:00
+        
+        // Some events (like multi-day retreats) don't have specific times
+        if (!timeText || !timeText.includes('-')) {
+            console.error(`No time range found for event, skipping time extraction`);
+            return undefined;
+        }
+        
         const [startTime] = timeText.split("-").map(time => time.trim());
         const [hours, minutes] = startTime.split(':').map(Number);
+        
+        // Validate time values
+        if (isNaN(hours) || isNaN(minutes)) {
+            console.error(`Invalid time values: hours=${hours}, minutes=${minutes}`);
+            return undefined;
+        }
 
         const ldEvent = extractLDJsonEvent(html);
         const startDate = new Date(ldEvent.startDate);
@@ -350,8 +363,21 @@ export class WebsiteScraper implements WebsiteScraperInterface {
     extractEndAt(html: string) {
         const $ = cheerio.load(html);
         const timeText = $('.mec-single-event-time abbr').text(); // 16:00 - 18:00
+        
+        // Some events (like multi-day retreats) don't have specific times
+        if (!timeText || !timeText.includes('-')) {
+            console.error(`No time range found for event, skipping time extraction`);
+            return undefined;
+        }
+        
         const [, endTime] = timeText.split("-").map(time => time.trim());
         const [hours, minutes] = endTime.split(':').map(Number);
+        
+        // Validate time values
+        if (isNaN(hours) || isNaN(minutes)) {
+            console.error(`Invalid time values: hours=${hours}, minutes=${minutes}`);
+            return undefined;
+        }
 
         const ldEvent = extractLDJsonEvent(html);
         const endDate = new Date(ldEvent.endDate);

--- a/scripts/scrape-seijetzt.ts
+++ b/scripts/scrape-seijetzt.ts
@@ -129,11 +129,24 @@ export class WebsiteScraper implements WebsiteScraperInterface {
         const dateMatch = xDataAttr.match(/new Date\((.*?)\)/);
         if (!dateMatch || !dateMatch[1]) throw new Error('No date match found in x-data attribute');
 
-        const [dateStr, timeStr] = dateMatch[1].replace(/['"]/g, '').split('T');
+        const dateTimeStr = dateMatch[1].replace(/['"]/g, '');
+        const [dateStr, timeStr] = dateTimeStr.split('T');
+        
+        // Validate date and time parts exist
+        if (!dateStr || !timeStr) {
+            throw new Error(`Invalid date-time format: ${dateTimeStr}`);
+        }
+        
         const [year, month, day] = dateStr.split('-').map(Number);
         const [hour, minute] = timeStr.split(':').map(Number);
-        if (isNaN(hour) || isNaN(minute) || hour < 0 || hour > 23 || minute < 0 || minute > 59) throw new Error('Invalid time parameters');
-        if (isNaN(day) || isNaN(month) || isNaN(year) || day < 1 || day > 31 || month < 0 || month > 11 || year < 1900 || year > 2100) throw new Error('Invalid date parameters');
+        
+        // Validate all date/time values are valid numbers
+        if (isNaN(hour) || isNaN(minute) || hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+            throw new Error(`Invalid time parameters: hour=${hour}, minute=${minute} from "${timeStr}"`);
+        }
+        if (isNaN(day) || isNaN(month) || isNaN(year) || day < 1 || day > 31 || month < 0 || month > 11 || year < 1900 || year > 2100) {
+            throw new Error(`Invalid date parameters: year=${year}, month=${month}, day=${day} from "${dateStr}"`);
+        }
 
         return dateToIsoStr(year, month, day, hour, minute, 'Europe/Berlin', true);
     }


### PR DESCRIPTION
## Summary

This PR fixes several scrapers that were failing in the GitHub Actions runs:

### Changes

#### kuschelraum scraper
- **Problem**: Multi-day retreat events (like "Kuschelreise Sardinien") don't have specific times in the expected format, causing 
- **Fix**: Added validation to check if  exists and contains a time range before parsing. Returns  for events without time info instead of crashing.

#### seijetzt scraper  
- **Problem**: Date parsing errors with unhelpful error messages ("Invalid time parameters")
- **Fix**: Added better error messages that include the actual values being parsed (e.g., ) to help diagnose issues with specific event URLs.

#### ggbrandenburg scraper
- **Problem**: Missing date/time elements in h5 could cause undefined errors
- **Fix**: Added validation to check if  exists and has content before attempting to parse.

### Screenshots

The fixes were developed by analyzing the failing runs:
- Run #22485763839 (2026-02-27 12:11)
- Run #22467313030 (2026-02-27 00:29)

### Testing

- [x] TypeScript compilation passes
- [ ] Full scraper test pending in CI

### Notes

The  scraper is also failing but this is due to Cloudflare bot protection blocking the scraper - this requires credential or approach changes outside the scope of this code fix.