### PR TITLE
Fix todo.today scraper - Improve Cloudflare error message

### DIFF
--- a/scripts/scrape-todotoday.ts
+++ b/scripts/scrape-todotoday.ts
@@ -394,6 +394,15 @@ export class WebsiteScraper implements WebsiteScraperInterface {
 		}, { config: safeConfig });
 
 		if (!apiResponse.ok) {
+			// Check if Cloudflare is blocking the request
+			if (apiResponse.status === 403 && apiResponse.body?.includes('Just a moment')) {
+				throw new Error(
+					`Cloudflare Turnstile blocking REST API for ${location}. ` +
+					`The site has implemented bot protection. ` +
+					`Status: ${apiResponse.status}. ` +
+					`Body: ${apiResponse.body?.slice(0, 200)}`
+				);
+			}
 			throw new Error(`REST API returned ${apiResponse.status} for ${location}: ${apiResponse.body?.slice(0, 200)}`);
 		}
 


### PR DESCRIPTION
## Problem
The `scrape-todotoday.ts` scraper is failing in GitHub Actions with a 403 error from the REST API.

## Root Cause
The todo.today website has implemented **Cloudflare Turnstile** bot protection, which detects the Playwright browser as an automated tool and blocks the REST API requests with a "Just a moment..." challenge page.

When the scraper attempts to call the REST API via `page.evaluate()`, Cloudflare intercepts the request and returns:
- Status: 403 Forbidden
- Body: HTML containing "Just a moment..." (Cloudflare challenge page)

## Solution
Added a clearer error message that explicitly identifies Cloudflare Turnstile as the cause of 403 errors. This helps maintainers quickly understand the issue without having to parse the HTML response.

### Before
```
error: REST API returned 403 for ubud: <!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title>...
```

### After
```
error: Cloudflare Turnstile blocking REST API for ubud. The site has implemented bot protection. Status: 403. Body: ...
```

## Note
This is a **technical limitation** - the site has implemented bot protection specifically to prevent automated scraping. Bypassing Cloudflare Turnstile would:
1. Likely violate the site's Terms of Service
2. Require external services or complex browser fingerprinting that may break easily

The scraper correctly fails with a descriptive error message so maintainers understand the underlying issue.

## Verification
- [x] Error message clearly identifies Cloudflare as the blocking entity
- [x] Original error behavior is preserved for non-Cloudflare errors
- [x] No events are silently skipped (fails fast as per project rules)