### PR TITLE
Add auth feedback dialog for magic link authentication

### DIFF
--- a/src/lib/components/AuthFeedbackDialog.svelte
+++ b/src/lib/components/AuthFeedbackDialog.svelte
@@ -1,0 +1,56 @@
+<script lang="ts" module>
+	let open = $state(false);
+	let message = $state('');
+	let type = $state<'success' | 'error'>('success');
+
+	export function showAuthFeedback(feedbackType: 'success' | 'error', feedbackMessage: string) {
+		type = feedbackType;
+		message = feedbackMessage;
+		open = true;
+	}
+
+	export function closeAuthFeedback() {
+		open = false;
+	}
+</script>
+
+<script lang="ts">
+	import { Dialog } from '$lib/components/dialog';
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Portal>
+		<Dialog.OverlayAnimated />
+		<Dialog.ContentAnimated class="bg-base-100 fixed top-1/2 left-1/2 z-50 max-h-[85vh] w-full max-w-sm -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg p-6 shadow-xl">
+			<div class="flex flex-col items-center text-center">
+				{#if type === 'success'}
+					<div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-success/20">
+						<i class="icon-[ph--check-circle] size-10 text-success"></i>
+					</div>
+					<Dialog.Title class="mb-2 text-xl font-semibold">Erfolgreich angemeldet</Dialog.Title>
+				{:else}
+					<div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-error/20">
+						<i class="icon-[ph--warning-circle] size-10 text-error"></i>
+					</div>
+					<Dialog.Title class="mb-2 text-xl font-semibold">Anmeldung fehlgeschlagen</Dialog.Title>
+				{/if}
+
+				<p class="text-base-content/80 mb-6">{message}</p>
+
+				<button 
+					onclick={() => open = false}
+					class="btn btn-primary w-full"
+				>
+					{type === 'success' ? 'Weiter' : 'Schließen'}
+				</button>
+			</div>
+
+			<Dialog.Close
+				class="hover:bg-base-200 absolute top-4 right-4 flex size-8 items-center justify-center rounded-full transition-colors"
+				aria-label="Schließen"
+			>
+				<i class="icon-[ph--x] size-6"></i>
+			</Dialog.Close>
+		</Dialog.ContentAnimated>
+	</Dialog.Portal>
+</Dialog.Root>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
 	import { page, updated } from '$app/state';
 	import { pwaInfo } from 'virtual:pwa-info';
 	import { pwaAssetsHead } from 'virtual:pwa-assets/head';
-	import { beforeNavigate, invalidate } from '$app/navigation';
+	import { beforeNavigate, invalidate, goto } from '$app/navigation';
 	import { MetaTags, deepMerge } from 'svelte-meta-tags';
 	import { onMount } from 'svelte';
 	import { setupAutoRefresh } from '$lib/auto-refresh';
@@ -13,6 +13,7 @@
 	import { navigationIsDelayed } from '$lib/components/navigationIsDelayed.svelte';
 	import { fade } from 'svelte/transition';
 	import LoginDialog from '$lib/components/LoginDialog.svelte';
+	import AuthFeedbackDialog, { showAuthFeedback } from '$lib/components/AuthFeedbackDialog.svelte';
 	import { resolve } from '$app/paths';
 	import TabsNavMobile from '$lib/components/TabsNavMobile.svelte';
 	import TabsNavDesktop from '$lib/components/TabsNavDesktop.svelte';
@@ -36,6 +37,23 @@
 
 	onMount(() => {
 		const cleanup = setupAutoRefresh();
+		
+		// Check for auth feedback from URL params
+		const url = new URL(window.location.href);
+		const authError = url.searchParams.get('auth_error');
+		const authSuccess = url.searchParams.get('auth_success');
+		
+		if (authError) {
+			showAuthFeedback('error', authError);
+			// Clean up URL params without reloading
+			url.searchParams.delete('auth_error');
+			goto(url.pathname + url.search, { replaceState: true });
+		} else if (authSuccess) {
+			showAuthFeedback('success', 'Du hast dich erfolgreich angemeldet. Willkommen zurück!');
+			// Clean up URL params without reloading
+			url.searchParams.delete('auth_success');
+			goto(url.pathname + url.search, { replaceState: true });
+		}
 		
 		// Listen to Auth events to handle session refreshes and signouts
 		const { data: authData } = supabase.auth.onAuthStateChange((event, newSession) => {
@@ -96,3 +114,4 @@
 {/if}
 
 <LoginDialog />
+<AuthFeedbackDialog />

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -10,15 +10,26 @@ import { db, eq, s } from '$lib/server/db';
 export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
 	const code = url.searchParams.get(`code`);
 	const next = url.searchParams.get(`next`) ?? `/`;
-	if (!code) return redirect(303, `/`);
+	if (!code) {
+		const errorUrl = new URL(next, url.origin);
+		errorUrl.searchParams.set('auth_error', 'Der Login-Link ist ungültig oder abgelaufen. Bitte fordere einen neuen an.');
+		return redirect(303, errorUrl);
+	}
 
 	const { error, data } = await supabase.auth.exchangeCodeForSession(code);
-	if (error || !data?.user) return redirect(303, `/`);
+	if (error || !data?.user) {
+		const errorUrl = new URL(next, url.origin);
+		errorUrl.searchParams.set('auth_error', error?.message ?? 'Anmeldung fehlgeschlagen. Bitte versuche es erneut.');
+		return redirect(303, errorUrl);
+	}
 
 	// Create profile if it doesn't exist
 	const dbUser = await db.query.profiles.findFirst({ where: eq(s.profiles.id, data.user.id) });
 	if (!dbUser) await db.insert(s.profiles).values({ id: data.user.id }).onConflictDoNothing();
 
-	redirect(303, next);
+	// Redirect with success message
+	const successUrl = new URL(next, url.origin);
+	successUrl.searchParams.set('auth_success', 'true');
+	redirect(303, successUrl);
 };
 


### PR DESCRIPTION
## Summary

Adds visual feedback when users click magic link authentication URLs. Previously, users were silently redirected without knowing if the login succeeded or failed.

## Changes

- **New component:** `AuthFeedbackDialog.svelte` - A reusable dialog for showing success/error states
- **Updated callback handler:** Now passes `auth_error` or `auth_success` query parameters instead of silent redirects
- **Updated layout:** Listens for URL params on mount and displays the appropriate feedback dialog

## User Experience

| Scenario | Before | After |
|----------|--------|-------|
| Successful login | Silent redirect | ✅ "Du hast dich erfolgreich angemeldet" dialog |
| Invalid/expired link | Silent redirect to `/` | ❌ "Der Login-Link ist ungültig oder abgelaufen" dialog |
| Exchange error | Silent redirect to `/` | ❌ Shows specific error message from Supabase |

## Technical Details

- URL parameters are cleaned up after displaying the dialog (using `replaceState` to avoid polluting browser history)
- Uses existing dialog components from `bits-ui` for consistency
- German copy matches the existing app language

Improves auth UX for magic link flow
