### PR TITLE
Fix sei.jetzt event image scraping

### DIFF
--- a/scripts/scrape-seijetzt.ts
+++ b/scripts/scrape-seijetzt.ts
@@ -211,15 +211,37 @@ export class WebsiteScraper implements WebsiteScraperInterface {
     extractImageUrls(html: string): string[] | undefined {
         const $ = cheerio.load(html, { decodeEntities: true });
         const imageUrlsSet = new Set<string>();
-        $('.h-20 img').each((_i, img) => {
-            const src = $(img).attr('src') || $(img).attr('data-src') || $(img).attr('data-lazy-src');
-            console.error({src});
-            if (src && !src.startsWith('data:') && !src.includes('placeholder') && !src.includes('-thumb') && src.length < 1200) {
-                try {
-                    imageUrlsSet.add(new URL(src, this.baseUrl).toString());
-                } catch { /* ignore */ }
-            }
+
+        const addImageUrl = (src: string | undefined) => {
+            if (!src?.length) return;
+            if (src.startsWith(`data:`) || src.includes(`placeholder`) || src.includes(`-thumb`)) return;
+            if (src.length >= 1200) return;
+            try {
+                imageUrlsSet.add(new URL(src, this.baseUrl).toString());
+            } catch { /* ignore */ }
+        };
+
+        // Event's own gallery carousel (related-events carousel uses a different embla without rounded-2xl)
+        $(`.embla.rounded-2xl img`).each((_i, img) => {
+            addImageUrl($(img).attr(`src`) || $(img).attr(`data-src`) || $(img).attr(`data-lazy-src`));
         });
+
+        // Single-image hero (mobile/desktop layouts), skip related-event thumbs
+        if (!imageUrlsSet.size) {
+            $(`main .aspect-square img`).each((_i, img) => {
+                const $img = $(img);
+                if ($img.closest(`.embla__slide__img`).length) return;
+                addImageUrl($img.attr(`src`) || $img.attr(`data-src`) || $img.attr(`data-lazy-src`));
+            });
+        }
+
+        // Fallback: og:image, prefer preview conversion over thumb
+        if (!imageUrlsSet.size) {
+            const ogImage = $(`meta[property="og:image"]`).attr(`content`);
+            if (ogImage) {
+                addImageUrl(ogImage.replace(/-thumb(\.[a-zA-Z0-9]+)$/, `-preview$1`));
+            }
+        }
 
         return imageUrlsSet.size > 0 ? Array.from(imageUrlsSet) : undefined;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
sei.jetzt redesigned their event detail pages, so the scraper’s `.h-20 img` selector no longer matched any images and events were scraped without covers.

## Fix
Update `extractImageUrls` in `scripts/scrape-seijetzt.ts` to:
1. Read images from the event’s own gallery (`.embla.rounded-2xl`)
2. Fall back to the single-image hero (`.aspect-square` outside related-event thumbs)
3. Fall back to `og:image`, upgrading `-thumb` to `-preview`

Related-event carousel images are intentionally excluded.

## Verification
Checked live event pages; each now returns the correct preview image URL(s), including multi-image galleries.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d988f9b8-7418-44c6-8434-df210767ecfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d988f9b8-7418-44c6-8434-df210767ecfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

